### PR TITLE
feat: infer display names from email and use in UI

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -2,6 +2,7 @@ import { convexAuth, getAuthUserId } from "@convex-dev/auth/server";
 import { Password } from "@convex-dev/auth/providers/Password";
 import { Anonymous } from "@convex-dev/auth/providers/Anonymous";
 import { query } from "./_generated/server";
+import { inferNameFromEmail } from "./utils";
 
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   providers: [Password, Anonymous],
@@ -10,13 +11,10 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
 export const loggedInUser = query({
   handler: async (ctx) => {
     const userId = await getAuthUserId(ctx);
-    if (!userId) {
-      return null;
-    }
+    if (!userId) return null;
     const user = await ctx.db.get(userId);
-    if (!user) {
-      return null;
-    }
-    return user;
+    if (!user) return null;
+    const displayName = (user as any).name || inferNameFromEmail((user as any).email);
+    return { ...user, displayName } as any;
   },
 });

--- a/convex/presentations.ts
+++ b/convex/presentations.ts
@@ -1,6 +1,7 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
+import { inferNameFromEmail } from "./utils";
 
 // Get next Thursday's date
 function getNextThursday(): string {
@@ -171,8 +172,8 @@ export const signUpToPresent = mutation({
     
     await ctx.db.insert("presentations", {
       title: args.title.trim(),
-      presenterName: user.name || user.email || "Anonymous",
-      presenterEmail: user.email || "",
+      presenterName: (user.name as string | undefined) || inferNameFromEmail(user.email as string | undefined) || (user.email as string | undefined) || "Anonymous",
+      presenterEmail: (user.email as string | undefined) || "",
       meetingDate,
       signupTime: Date.now(),
     });

--- a/convex/utils.ts
+++ b/convex/utils.ts
@@ -1,0 +1,21 @@
+export function inferNameFromEmail(email: string | undefined | null): string | null {
+  if (!email) return null;
+  try {
+    const local = email.split("@")[0] ?? "";
+    // Strip "+tag" parts, digits at the end, and non-letter separators
+    const base = local.split("+")[0]!.replace(/[\d]+$/g, "");
+    const parts = base
+      .replace(/[._-]+/g, " ")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    if (parts.length === 0) return null;
+    const pretty = parts
+      .map((p) => p.charAt(0).toUpperCase() + p.slice(1).toLowerCase())
+      .join(" ");
+    return pretty || null;
+  } catch {
+    return null;
+  }
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { SignOutButton } from "./SignOutButton";
 import { Toaster, toast } from "sonner";
 import { useState } from "react";
 import { Id } from "../convex/_generated/dataModel";
+import { inferNameFromEmailClient } from "@/lib/utils";
 
 export default function App() {
   return (
@@ -694,7 +695,11 @@ function PresentationItem({
                 {presentation.title}
               </h4>
               <p className={subtitleClasses}>
-                by {presentation.presenterName}
+                by {
+                  presentation.presenterName?.includes("@") && presentation.presenterEmail
+                    ? inferNameFromEmailClient(presentation.presenterEmail) || presentation.presenterName
+                    : presentation.presenterName
+                }
                 {isAdmin && !isOwner && (
                   <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 text-xs font-mono rounded">
                     ADMIN VIEW

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function inferNameFromEmailClient(email?: string | null): string | null {
+  if (!email) return null;
+  const local = email.split("@")[0] ?? "";
+  const base = local.split("+")[0]!.replace(/[\d]+$/g, "");
+  const parts = base.replace(/[._-]+/g, " ").trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return null;
+  return parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1).toLowerCase()).join(" ");
+}


### PR DESCRIPTION
Summary: Infer user‑friendly names from work emails (e.g., kyle_kincer@sweetwater.com → Kyle Kincer) and use them across the UI and stored presentation records.

Server:
- Added `convex/utils.ts` with robust email→name inference.
- `convex/auth.ts`: `loggedInUser` now includes `displayName` (explicit name → inferred → null).
- `convex/presentations.ts`: stores `presenterName` using explicit name or inferred name; fallback to email or “Anonymous”.

Client:
- `src/lib/utils.ts`: `inferNameFromEmailClient` for graceful rendering.
- `src/App.tsx`: shows inferred name if a raw email slips through.

Rationale: Most signups use work emails; this improves readability without requiring manual profile edits.

UI impact: Presenter lines show “First Last” instead of raw emails.

Testing:
- Sign up with `first_last@company.com`; verify “First Last” appears in the list.
- Existing rows with prior emails render inferred names client‑side.

Notes:
- Handles `.`, `_`, `-`, and "+" tags; trims trailing digits.
- Non‑Latin/edge formats fallback gracefully.
