### PR TITLE
feat: streamline admin interface

### DIFF
--- a/src/AdminPanel.tsx
+++ b/src/AdminPanel.tsx
@@ -1,0 +1,221 @@
+import { useQuery, useMutation } from "convex/react";
+import { api } from "../convex/_generated/api";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+export function AdminPanel({ onClose }: { onClose: () => void }) {
+  const upcomingMeeting = useQuery(api.presentations.getUpcomingMeeting);
+  const defaultDate = upcomingMeeting?.date || new Date().toISOString().split("T")[0];
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white border-2 border-black max-w-3xl w-full p-6 relative overflow-y-auto max-h-[90vh]">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 px-3 py-1 border-2 border-black hover:bg-black hover:text-white font-mono text-sm"
+        >
+          CLOSE
+        </button>
+        <div className="space-y-6 mt-4">
+          <BackfillManager defaultMeetingDate={defaultDate} />
+          <AdminManager />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BackfillManager({ defaultMeetingDate }: { defaultMeetingDate: string }) {
+  const [meetingDate, setMeetingDate] = useState(defaultMeetingDate);
+  useEffect(() => {
+    setMeetingDate(defaultMeetingDate);
+  }, [defaultMeetingDate]);
+  const [presenterEmail, setPresenterEmail] = useState("");
+  const [presenterName, setPresenterName] = useState("");
+  const [title, setTitle] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const adminAddPresentation = useMutation((api as any).presentations.adminAddPresentation);
+
+  const handleAdd = async () => {
+    if (!title.trim() || !presenterEmail.trim() || !meetingDate) return;
+    setIsSubmitting(true);
+    try {
+      await adminAddPresentation({
+        title: title.trim(),
+        meetingDate,
+        presenterEmail: presenterEmail.trim(),
+        presenterName: presenterName.trim() || undefined,
+      });
+      toast.success("Presentation backfilled!");
+      setTitle("");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to add presentation");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-gray-50 border-2 border-black p-4 rounded">
+      <h5 className="font-bold mb-3">ADMIN: Backfill Presentation</h5>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-2">
+        <div>
+          <label className="block text-xs font-mono mb-1">Meeting Date</label>
+          <input
+            type="date"
+            value={meetingDate}
+            onChange={(e) => setMeetingDate(e.target.value)}
+            className="w-full p-2 border-2 border-black font-mono text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-mono mb-1">Presenter Email</label>
+          <input
+            type="email"
+            value={presenterEmail}
+            onChange={(e) => setPresenterEmail(e.target.value)}
+            placeholder="user@company.com"
+            className="w-full p-2 border-2 border-black font-mono text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-mono mb-1">Presenter Name (optional)</label>
+          <input
+            type="text"
+            value={presenterName}
+            onChange={(e) => setPresenterName(e.target.value)}
+            placeholder="Auto-infers from email if blank"
+            className="w-full p-2 border-2 border-black font-mono text-sm"
+          />
+        </div>
+        <div className="md:col-span-4">
+          <label className="block text-xs font-mono mb-1">Title</label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Enter presentation title"
+              className="flex-1 p-2 border-2 border-black font-mono text-sm"
+              maxLength={200}
+            />
+            <button
+              onClick={handleAdd}
+              disabled={!title.trim() || !presenterEmail.trim() || !meetingDate || isSubmitting}
+              className="px-3 py-2 bg-black text-white text-sm font-mono hover:bg-gray-800 disabled:bg-gray-300"
+            >
+              ADD
+            </button>
+          </div>
+        </div>
+      </div>
+      <p className="text-xs mt-2">Adds immediately, even for past or inactive weeks.</p>
+    </div>
+  );
+}
+
+function AdminManager() {
+  const admins = useQuery(api.presentations.listAdmins);
+  const addAdmin = useMutation(api.presentations.addAdmin);
+  const removeAdmin = useMutation(api.presentations.removeAdmin);
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [confirmEmail, setConfirmEmail] = useState<string | null>(null);
+
+  const handleAdd = async () => {
+    if (!email.trim()) return;
+    setIsSubmitting(true);
+    try {
+      await addAdmin({ email: email.trim() });
+      toast.success("Admin added");
+      setEmail("");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to add admin");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleRemove = async (targetEmail: string) => {
+    setIsSubmitting(true);
+    try {
+      await removeAdmin({ email: targetEmail });
+      toast.success("Admin removed");
+      setConfirmEmail(null);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to remove admin");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-gray-50 border-2 border-black p-4 rounded">
+      <h5 className="font-bold mb-3">ADMIN: Manage Admins</h5>
+      <div className="flex gap-2 mb-3">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="user@company.com"
+          className="flex-1 p-2 border-2 border-black font-mono text-sm"
+        />
+        <button
+          onClick={handleAdd}
+          disabled={!email.trim() || isSubmitting}
+          className="px-3 py-2 bg-black text-white text-sm font-mono hover:bg-gray-800 disabled:bg-gray-300"
+        >
+          ADD ADMIN
+        </button>
+      </div>
+
+      <div className="border-2 border-black">
+        <div className="px-3 py-2 bg-gray-100 text-xs font-mono border-b-2 border-black">CURRENT ADMINS</div>
+        <div className="divide-y-2 divide-black/10">
+          {admins === undefined ? (
+            <div className="p-3 text-sm text-gray-500">Loading...</div>
+          ) : admins.length === 0 ? (
+            <div className="p-3 text-sm text-gray-500">No admins found</div>
+          ) : (
+            admins.map((a: any) => (
+              <div key={a._id} className="p-3 flex items-center justify-between">
+                <div>
+                  <div className="text-sm font-mono">{a.email}</div>
+                  <div className="text-xs text-gray-500">
+                    added by {a.addedBy} • {new Date(a.addedAt).toLocaleString()}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {confirmEmail === a.email ? (
+                    <>
+                      <button
+                        onClick={() => handleRemove(a.email)}
+                        disabled={isSubmitting}
+                        className="px-3 py-1 bg-red-600 text-white text-xs font-mono hover:bg-red-700"
+                      >
+                        CONFIRM
+                      </button>
+                      <button
+                        onClick={() => setConfirmEmail(null)}
+                        className="px-3 py-1 border-2 border-black text-xs font-mono hover:bg-gray-100"
+                      >
+                        CANCEL
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      onClick={() => setConfirmEmail(a.email)}
+                      className="px-3 py-1 border-2 border-red-600 text-red-600 text-xs font-mono hover:bg-red-50"
+                    >
+                      REMOVE
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+      <p className="text-xs text-gray-600 mt-2">You cannot remove yourself; backend prevents it.</p>
+    </div>
+  );
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Toaster, toast } from "sonner";
 import { useEffect, useState } from "react";
 import { Id } from "../convex/_generated/dataModel";
 import { inferNameFromEmailClient } from "@/lib/utils";
+import { AdminPanel } from "./AdminPanel";
 
 export default function App() {
   return (
@@ -50,6 +51,7 @@ function AuthenticatedContent() {
   const upcomingMeeting = useQuery(api.presentations.getUpcomingMeeting);
   const [selectedWeek, setSelectedWeek] = useState<string | null>(null);
   const [showWeekSelector, setShowWeekSelector] = useState(false);
+  const [showAdminPanel, setShowAdminPanel] = useState(false);
   const availableWeeks = useQuery(api.presentations.getAvailableWeeks);
   const selectedWeekData = useQuery(
     api.presentations.getPresentationsByDate,
@@ -74,6 +76,17 @@ function AuthenticatedContent() {
 
   return (
     <div className="space-y-12">
+      {isAdmin && (
+        <div className="flex justify-end">
+          <button
+            onClick={() => setShowAdminPanel(true)}
+            className="px-3 py-1 border-2 border-black hover:bg-black hover:text-white font-mono text-sm"
+          >
+            ADMIN PANEL
+          </button>
+        </div>
+      )}
+
       {/* Next Meeting Section */}
       <section className="text-center space-y-6">
         <div>
@@ -224,22 +237,20 @@ function AuthenticatedContent() {
             )}
           </div>
 
-          {/* Admin Controls */}
-          {isAdmin && (
-            <div className="space-y-4">
-              <BackfillManager defaultMeetingDate={currentData.date} />
-              <RecordingManager 
-                meetingDate={currentData.date} 
-                currentRecordingUrl={currentData.recordingUrl} 
-              />
-              <InactiveWeekManager 
-                meetingDate={currentData.date}
-                isInactive={isInactiveWeek}
-                inactiveReason={currentData.inactiveReason}
-              />
-              <AdminManager />
-            </div>
-          )}
+        {/* Admin Controls */}
+        {isAdmin && (
+          <div className="space-y-4">
+            <RecordingManager
+              meetingDate={currentData.date}
+              currentRecordingUrl={currentData.recordingUrl}
+            />
+            <InactiveWeekManager
+              meetingDate={currentData.date}
+              isInactive={isInactiveWeek}
+              inactiveReason={currentData.inactiveReason}
+            />
+          </div>
+        )}
           
           {currentData.presentations.length === 0 ? (
             <div className={`text-center py-8 border-2 ${
@@ -280,16 +291,20 @@ function AuthenticatedContent() {
           )}
         </div>
       </section>
+      {showAdminPanel && (
+        <AdminPanel onClose={() => setShowAdminPanel(false)} />
+      )}
     </div>
   );
 }
 
-function InactiveWeekManager({ 
-  meetingDate, 
+
+function InactiveWeekManager({
+  meetingDate,
   isInactive,
   inactiveReason
-}: { 
-  meetingDate: string; 
+}: {
+  meetingDate: string;
   isInactive: boolean;
   inactiveReason?: string;
 }) {
@@ -334,31 +349,25 @@ function InactiveWeekManager({
   };
 
   return (
-    <div className={`border-2 p-4 rounded ${
-      isInactive ? "bg-gray-50 border-gray-300" : "bg-orange-50 border-orange-200"
-    }`}>
+    <div className="border-2 border-black p-4 rounded bg-gray-50">
       <div className="flex items-center justify-between mb-2">
-        <h5 className={`font-bold ${
-          isInactive ? "text-gray-700" : "text-orange-800"
-        }`}>
-          ADMIN: Week Status
-        </h5>
-        <div className={`px-2 py-1 text-xs font-bold rounded ${
-          isInactive 
-            ? "bg-gray-200 text-gray-700" 
-            : "bg-green-200 text-green-700"
-        }`}>
+        <h5 className="font-bold">ADMIN: Week Status</h5>
+        <div
+          className={`px-2 py-1 text-xs font-bold rounded ${
+            isInactive ? "bg-gray-200 text-gray-800" : "bg-green-200 text-green-800"
+          }`}
+        >
           {isInactive ? "[INACTIVE]" : "[ACTIVE]"}
         </div>
       </div>
-      
+
       {isEditing ? (
         <div className="space-y-3">
           <textarea
             value={reason}
             onChange={(e) => setReason(e.target.value)}
             placeholder="Optional reason for marking week as inactive"
-            className="w-full p-2 border-2 border-orange-300 font-mono text-sm resize-none"
+            className="w-full p-2 border-2 border-black font-mono text-sm resize-none"
             rows={2}
             disabled={isSubmitting}
           />
@@ -366,14 +375,14 @@ function InactiveWeekManager({
             <button
               onClick={handleMarkInactive}
               disabled={isSubmitting}
-              className="px-3 py-1 bg-orange-600 text-white font-bold text-sm hover:bg-orange-700 disabled:bg-gray-300"
+              className="px-3 py-1 bg-black text-white font-mono text-sm hover:bg-gray-800 disabled:bg-gray-300"
             >
               MARK INACTIVE
             </button>
             <button
               onClick={handleCancel}
               disabled={isSubmitting}
-              className="px-3 py-1 border-2 border-gray-400 text-gray-600 text-sm hover:bg-gray-50"
+              className="px-3 py-1 border-2 border-black text-sm font-mono hover:bg-gray-100"
             >
               CANCEL
             </button>
@@ -382,13 +391,10 @@ function InactiveWeekManager({
       ) : (
         <div className="flex items-center justify-between">
           <div>
-            <p className={`text-sm ${
-              isInactive ? "text-gray-600" : "text-orange-700"
-            }`}>
-              {isInactive 
+            <p className="text-sm">
+              {isInactive
                 ? `Week is inactive. ${inactiveReason ? `Reason: ${inactiveReason}` : "No reason provided."}`
-                : "Week is active and accepting signups"
-              }
+                : "Week is active and accepting signups"}
             </p>
           </div>
           <div className="flex space-x-2">
@@ -396,14 +402,14 @@ function InactiveWeekManager({
               <button
                 onClick={handleMarkActive}
                 disabled={isSubmitting}
-                className="px-3 py-1 bg-green-600 text-white text-sm font-mono hover:bg-green-700"
+                className="px-3 py-1 bg-black text-white text-sm font-mono hover:bg-gray-800"
               >
                 MARK ACTIVE
               </button>
             ) : (
               <button
                 onClick={() => setIsEditing(true)}
-                className="px-3 py-1 border-2 border-orange-600 text-orange-600 text-sm font-mono hover:bg-orange-50"
+                className="px-3 py-1 border-2 border-black text-sm font-mono hover:bg-gray-100"
               >
                 MARK INACTIVE
               </button>
@@ -414,208 +420,6 @@ function InactiveWeekManager({
     </div>
   );
 }
-
-function AdminManager() {
-  const admins = useQuery(api.presentations.listAdmins);
-  const addAdmin = useMutation(api.presentations.addAdmin);
-  const removeAdmin = useMutation(api.presentations.removeAdmin);
-  const [email, setEmail] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [confirmEmail, setConfirmEmail] = useState<string | null>(null);
-
-  const handleAdd = async () => {
-    if (!email.trim()) return;
-    setIsSubmitting(true);
-    try {
-      await addAdmin({ email: email.trim() });
-      toast.success("Admin added");
-      setEmail("");
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to add admin");
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleRemove = async (targetEmail: string) => {
-    setIsSubmitting(true);
-    try {
-      await removeAdmin({ email: targetEmail });
-      toast.success("Admin removed");
-      setConfirmEmail(null);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to remove admin");
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <div className="bg-gray-50 border-2 border-gray-300 p-4 rounded">
-      <h5 className="font-bold text-gray-800 mb-3">ADMIN: Manage Admins</h5>
-      <div className="flex gap-2 mb-3">
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="user@company.com"
-          className="flex-1 p-2 border-2 border-gray-300 font-mono text-sm"
-        />
-        <button
-          onClick={handleAdd}
-          disabled={!email.trim() || isSubmitting}
-          className="px-3 py-2 bg-gray-900 text-white text-sm font-bold hover:bg-black disabled:bg-gray-300"
-        >
-          ADD ADMIN
-        </button>
-      </div>
-
-      <div className="border-2 border-gray-200">
-        <div className="px-3 py-2 bg-gray-100 text-xs font-mono text-gray-700 border-b-2 border-gray-200">
-          CURRENT ADMINS
-        </div>
-        <div className="divide-y-2 divide-gray-200">
-          {admins === undefined ? (
-            <div className="p-3 text-sm text-gray-500">Loading...</div>
-          ) : admins.length === 0 ? (
-            <div className="p-3 text-sm text-gray-500">No admins found</div>
-          ) : (
-            admins.map((a: any) => (
-              <div key={a._id} className="p-3 flex items-center justify-between">
-                <div>
-                  <div className="text-sm font-mono">{a.email}</div>
-                  <div className="text-xs text-gray-500">
-                    added by {a.addedBy} • {new Date(a.addedAt).toLocaleString()}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  {confirmEmail === a.email ? (
-                    <>
-                      <button
-                        onClick={() => handleRemove(a.email)}
-                        disabled={isSubmitting}
-                        className="px-3 py-1 bg-red-600 text-white text-xs font-bold hover:bg-red-700"
-                      >
-                        CONFIRM
-                      </button>
-                      <button
-                        onClick={() => setConfirmEmail(null)}
-                        className="px-3 py-1 border-2 border-gray-400 text-gray-700 text-xs font-mono hover:bg-gray-50"
-                      >
-                        CANCEL
-                      </button>
-                    </>
-                  ) : (
-                    <button
-                      onClick={() => setConfirmEmail(a.email)}
-                      className="px-3 py-1 border-2 border-red-600 text-red-600 text-xs font-mono hover:bg-red-50"
-                    >
-                      REMOVE
-                    </button>
-                  )}
-                </div>
-              </div>
-            ))
-          )}
-        </div>
-      </div>
-      <p className="text-xs text-gray-600 mt-2">You cannot remove yourself; backend prevents it.</p>
-    </div>
-  );
-}
-
-function BackfillManager({ defaultMeetingDate }: { defaultMeetingDate: string }) {
-  const [meetingDate, setMeetingDate] = useState(defaultMeetingDate);
-  // Keep local date in sync when navigating weeks
-  useEffect(() => {
-    setMeetingDate(defaultMeetingDate);
-  }, [defaultMeetingDate]);
-  const [presenterEmail, setPresenterEmail] = useState("");
-  const [presenterName, setPresenterName] = useState("");
-  const [title, setTitle] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  // Cast to any to avoid type errors before Convex codegen updates
-  const adminAddPresentation = useMutation((api as any).presentations.adminAddPresentation);
-
-  const handleAdd = async () => {
-    if (!title.trim() || !presenterEmail.trim() || !meetingDate) return;
-    setIsSubmitting(true);
-    try {
-      await adminAddPresentation({
-        title: title.trim(),
-        meetingDate,
-        presenterEmail: presenterEmail.trim(),
-        presenterName: presenterName.trim() || undefined,
-      });
-      toast.success("Presentation backfilled!");
-      setTitle("");
-      // Keep meetingDate and presenter info to speed multiple adds
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to add presentation");
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <div className="bg-purple-50 border-2 border-purple-200 p-4 rounded">
-      <h5 className="font-bold text-purple-800 mb-3">ADMIN: Backfill Presentation</h5>
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-2">
-        <div>
-          <label className="block text-xs text-purple-800 font-mono mb-1">Meeting Date</label>
-          <input
-            type="date"
-            value={meetingDate}
-            onChange={(e) => setMeetingDate(e.target.value)}
-            className="w-full p-2 border-2 border-purple-300 font-mono text-sm"
-          />
-        </div>
-        <div>
-          <label className="block text-xs text-purple-800 font-mono mb-1">Presenter Email</label>
-          <input
-            type="email"
-            value={presenterEmail}
-            onChange={(e) => setPresenterEmail(e.target.value)}
-            placeholder="user@company.com"
-            className="w-full p-2 border-2 border-purple-300 font-mono text-sm"
-          />
-        </div>
-        <div>
-          <label className="block text-xs text-purple-800 font-mono mb-1">Presenter Name (optional)</label>
-          <input
-            type="text"
-            value={presenterName}
-            onChange={(e) => setPresenterName(e.target.value)}
-            placeholder="Auto-infers from email if blank"
-            className="w-full p-2 border-2 border-purple-300 font-mono text-sm"
-          />
-        </div>
-        <div className="md:col-span-4">
-          <label className="block text-xs text-purple-800 font-mono mb-1">Title</label>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="Enter presentation title"
-              className="flex-1 p-2 border-2 border-purple-300 font-mono text-sm"
-              maxLength={200}
-            />
-            <button
-              onClick={handleAdd}
-              disabled={!title.trim() || !presenterEmail.trim() || !meetingDate || isSubmitting}
-              className="px-3 py-2 bg-purple-700 text-white text-sm font-bold hover:bg-purple-800 disabled:bg-gray-300"
-            >
-              ADD
-            </button>
-          </div>
-        </div>
-      </div>
-      <p className="text-xs text-purple-700 mt-2">Adds immediately, even for past or inactive weeks.</p>
-    </div>
-  );
-}
-
 function RecordingManager({ 
   meetingDate, 
   currentRecordingUrl 
@@ -667,15 +471,15 @@ function RecordingManager({
   };
 
   return (
-    <div className="bg-blue-50 border-2 border-blue-200 p-4 rounded">
+    <div className="bg-gray-50 border-2 border-black p-4 rounded">
       <div className="flex items-center justify-between mb-2">
-        <h5 className="font-bold text-blue-800">ADMIN: Recording Link</h5>
+        <h5 className="font-bold">ADMIN: Recording Link</h5>
         {currentRecordingUrl && !isEditing && (
           <a
             href={currentRecordingUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="px-3 py-1 bg-blue-600 text-white font-mono text-sm hover:bg-blue-700 transition-colors"
+            className="px-3 py-1 border-2 border-black bg-black text-white font-mono text-sm hover:bg-gray-800"
           >
             [VIEW]
           </a>
@@ -689,21 +493,21 @@ function RecordingManager({
             value={recordingUrl}
             onChange={(e) => setRecordingUrl(e.target.value)}
             placeholder="Enter recording URL (YouTube, Zoom, etc.)"
-            className="w-full p-2 border-2 border-blue-300 font-mono text-sm"
+            className="w-full p-2 border-2 border-black font-mono text-sm"
             disabled={isSubmitting}
           />
           <div className="flex space-x-2">
             <button
               onClick={handleSave}
               disabled={!recordingUrl.trim() || isSubmitting}
-              className="px-3 py-1 bg-green-600 text-white font-bold text-sm hover:bg-green-700 disabled:bg-gray-300"
+              className="px-3 py-1 bg-black text-white font-mono text-sm hover:bg-gray-800 disabled:bg-gray-300"
             >
               SAVE
             </button>
             <button
               onClick={handleCancel}
               disabled={isSubmitting}
-              className="px-3 py-1 border-2 border-gray-400 text-gray-600 text-sm hover:bg-gray-50"
+              className="px-3 py-1 border-2 border-black text-sm font-mono hover:bg-gray-100"
             >
               CANCEL
             </button>
@@ -711,7 +515,7 @@ function RecordingManager({
               <button
                 onClick={handleRemove}
                 disabled={isSubmitting}
-                className="px-3 py-1 bg-red-600 text-white font-bold text-sm hover:bg-red-700"
+                className="px-3 py-1 bg-red-600 text-white text-sm font-mono hover:bg-red-700"
               >
                 REMOVE
               </button>
@@ -720,12 +524,12 @@ function RecordingManager({
         </div>
       ) : (
         <div className="flex items-center justify-between">
-          <p className="text-sm text-blue-700">
+          <p className="text-sm">
             {currentRecordingUrl ? "Recording link is set" : "No recording link set"}
           </p>
           <button
             onClick={() => setIsEditing(true)}
-            className="px-3 py-1 border-2 border-blue-600 text-blue-600 text-sm font-mono hover:bg-blue-50"
+            className="px-3 py-1 border-2 border-black text-sm font-mono hover:bg-gray-100"
           >
             {currentRecordingUrl ? "EDIT" : "ADD LINK"}
           </button>


### PR DESCRIPTION
## Summary
- move admin management and backfill into a dedicated modal panel
- simplify remaining week controls with cleaner styling

## Testing
- `npm run lint` *(fails: Convex login prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f8941a68832484ade623fc528bf3